### PR TITLE
feat(product): 상품 갤러리·라이트박스·정보 섹션 틀 구현

### DIFF
--- a/app/components/ProductGallery.tsx
+++ b/app/components/ProductGallery.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import { product } from "../data/product";
+import Image from "next/image";
+import { ProductLightbox } from "./ProductLightbox";
+
+export function ProductGallery() {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
+  const [lightboxOpen, setLightboxOpen] = useState(false);
+
+  // embla <-> state 동기화
+  useEffect(() => {
+    if (!emblaApi) return;
+    const onSelect = () => setSelectedIndex(emblaApi.selectedScrollSnap());
+    emblaApi.on("select", onSelect);
+    onSelect();
+    return () => {
+      emblaApi.off("select", onSelect);
+    };
+  }, [emblaApi]);
+
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+
+  const handleMainClick = () => {
+    // 데스크톱에서만 라이트박스
+    if (typeof window === "undefined") return;
+    if (window.matchMedia("(min-width: 768px)").matches) {
+      setLightboxOpen(true);
+    }
+  };
+
+  return (
+    <div className="w-full lg:max-w-md">
+      {/* 메인 이미지 + Embla viewport */}
+      <div className="relative">
+        <div className="overflow-hidden md:rounded-xl" ref={emblaRef}>
+          <div className="flex">
+            {product.images.map((img, i) => (
+              <button
+                key={img.full}
+                type="button"
+                onClick={handleMainClick}
+                aria-label="Open fullscreen gallery"
+                className="relative aspect-square flex-[0_0_100%] md:cursor-pointer"
+              >
+                <Image
+                  src={img.full}
+                  alt={`Product image ${i + 1}`}
+                  fill
+                  className="object-cover"
+                  priority={i === 0}
+                  sizes="(min-width: 1024px) 28rem, 100vw"
+                />
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 모바일 전용 */}
+        <button
+          type="button"
+          onClick={scrollPrev}
+          aria-label="Previous image"
+          className="absolute top-1/2 left-4 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-md md:hidden"
+        >
+          <Image src="/icon-previous.svg" alt="" width={12} height={14} />
+        </button>
+        <button
+          type="button"
+          onClick={scrollNext}
+          aria-label="Next image"
+          className="absolute top-1/2 right-4 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-white shadow-md md:hidden"
+        >
+          <Image src="/icon-next.svg" alt="" width={12} height={14} />
+        </button>
+      </div>
+
+      {/* 썸네일 (md+ 전용) */}
+      <div className="mt-8 hidden grid-cols-4 gap-6 md:grid">
+        {product.images.map((img, i) => {
+          const active = i === selectedIndex;
+          return (
+            <button
+              key={img.thumb}
+              type="button"
+              onClick={() => scrollTo(i)}
+              aria-label={`Select image ${i + 1}`}
+              aria-current={active}
+              className={`relative aspect-square overflow-hidden rounded-lg transition ${active ? "ring-primary ring-2" : "hover:opacity-75"}`}
+            >
+              <Image
+                src={img.thumb}
+                alt=""
+                fill
+                className={`object-cover ${active ? "opacity-50" : ""}`}
+                sizes="6rem"
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <ProductLightbox
+        open={lightboxOpen}
+        initialIndex={selectedIndex}
+        onClose={() => setLightboxOpen(false)}
+      />
+    </div>
+  );
+}

--- a/app/components/ProductInfo.tsx
+++ b/app/components/ProductInfo.tsx
@@ -1,0 +1,68 @@
+import Image from "next/image";
+import { product } from "../data/product";
+
+export function ProductInfo() {
+  return (
+    <section className="flex flex-col gap-4 px-6 py-6 md:px-0 lg:gap-6 lg:py-0">
+      <p className="text-primary text-xs font-bold tracking-[0.15em] uppercase lg:text-sm">
+        {product.company}
+      </p>
+
+      <h1 className="text-foreground text-3xl leading-tight font-bold lg:text-4xl">
+        {product.name}
+      </h1>
+
+      <p className="text-muted lg:text-base">{product.description}</p>
+
+      {/* 가격 */}
+      <div className="flex items-center justify-between lg:flex-col lg:items-start lg:gap-2">
+        <div className="flex items-center gap-4">
+          <span className="text-foreground text-3xl font-bold">${product.price.toFixed(2)}</span>
+          <span className="bg-foreground rounded-md px-2 py-0.5 text-sm font-bold text-white">
+            {product.discountPercent}%
+          </span>
+        </div>
+        <span className="text-muted text-sm font-bold line-through">
+          ${product.originalPrice.toFixed(2)}
+        </span>
+      </div>
+
+      {/* 수량 + Add to cart */}
+      <div className="mt-2 flex flex-col gap-4 lg:mt-4 lg:flex-row">
+        {/* 수량 (틀만) */}
+        <div className="bg-surface flex items-center justify-between rounded-lg px-5 py-4 lg:w-40">
+          <button
+            type="button"
+            aria-label="Decrease quantity"
+            className="cursor-pointer transition hover:opacity-50"
+          >
+            <Image src="/icon-minus.svg" alt="" width={12} height={4} />
+          </button>
+          <span className="text-foreground font-bold">0</span>
+          <button
+            type="button"
+            aria-label="Increase quantity"
+            className="cursor-pointer transition hover:opacity-50"
+          >
+            <Image src="/icon-plus.svg" alt="" width={12} height={12} />
+          </button>
+        </div>
+
+        {/* Add to cart (틀만) */}
+        <button
+          type="button"
+          className="bg-primary text-foreground shadow-primary/25 flex flex-1 cursor-pointer items-center justify-center gap-4 rounded-lg px-6 py-4 font-bold shadow-lg transition hover:opacity-75"
+        >
+          <Image
+            src="/icon-cart.svg"
+            alt=""
+            width={18}
+            height={16}
+            className="[filter:brightness(0)]"
+          />
+          Add to cart
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/app/components/ProductLightbox.tsx
+++ b/app/components/ProductLightbox.tsx
@@ -1,0 +1,148 @@
+import useEmblaCarousel from "embla-carousel-react";
+import Image from "next/image";
+import { useCallback, useEffect, useState } from "react";
+import { useEscapeKey } from "../hooks/useEscapeKey";
+import { product } from "../data/product";
+
+type Props = {
+  open: boolean;
+  initialIndex: number;
+  onClose: () => void;
+  onIndexChange?: (index: number) => void;
+};
+
+export function ProductLightbox({ open, initialIndex, onClose, onIndexChange }: Props) {
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    loop: true,
+    startIndex: initialIndex,
+  });
+  const [selectedIndex, setSelectedIndex] = useState(initialIndex);
+
+  // ESC로 닫기 (기존 훅 재사용)
+  useEscapeKey(onClose, open);
+
+  // body 스크롤 잠금
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // 열 때마다 initialIndex로 점프
+  useEffect(() => {
+    if (!open || !emblaApi) return;
+    emblaApi.scrollTo(initialIndex, true);
+    setSelectedIndex(initialIndex);
+  }, [open, initialIndex, emblaApi]);
+
+  // Embla ↔ state 동기화
+  useEffect(() => {
+    if (!emblaApi) return;
+    const onSelect = () => {
+      const i = emblaApi.selectedScrollSnap();
+      setSelectedIndex(i);
+      onIndexChange?.(i);
+    };
+    emblaApi.on("select", onSelect);
+    return () => {
+      emblaApi.off("select", onSelect);
+    };
+  }, [emblaApi, onIndexChange]);
+
+  const scrollTo = useCallback((i: number) => emblaApi?.scrollTo(i), [emblaApi]);
+  const scrollPrev = useCallback(() => emblaApi?.scrollPrev(), [emblaApi]);
+  const scrollNext = useCallback(() => emblaApi?.scrollNext(), [emblaApi]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Product image lightbox"
+      onClick={onClose}
+      className="fixed inset-0 z-50 hidden items-center justify-center bg-black/75 md:flex"
+    >
+      {/* 내부 영역: 백드롭 클릭 전파 차단 */}
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="flex w-full max-w-xl flex-col gap-8 px-4"
+      >
+        {/* 닫기 버튼 */}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            aria-label="Close lightbox"
+            onClick={onClose}
+            className="group cursor-pointer"
+          >
+            <Image src="/icon-close.svg" alt="close" width={20} height={20} />
+          </button>
+        </div>
+
+        {/* 메인 이미지 + prev/next */}
+        <div className="relative">
+          <div className="overflow-hidden rounded-xl" ref={emblaRef}>
+            <div className="flex">
+              {product.images.map((img, i) => (
+                <div key={img.full} className="relative aspect-square flex-[0_0_100%]">
+                  <Image
+                    src={img.full}
+                    alt={`Product image ${i + 1}`}
+                    fill
+                    className="object-cover"
+                    sizes="36rem"
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={scrollPrev}
+            aria-label="Previous image"
+            className="group absolute top-1/2 -left-6 flex h-12 w-12 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-white"
+          >
+            <Image src="/icon-previous.svg" alt="" width={12} height={14} />
+          </button>
+          <button
+            type="button"
+            onClick={scrollNext}
+            aria-label="Next image"
+            className="group absolute top-1/2 -right-6 flex h-12 w-12 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-white"
+          >
+            <Image src="/icon-next.svg" alt="" width={12} height={14} />
+          </button>
+        </div>
+
+        {/* 썸네일 */}
+        <div className="grid grid-cols-4 gap-6 px-8">
+          {product.images.map((img, i) => {
+            const active = i === selectedIndex;
+            return (
+              <button
+                key={img.thumb}
+                type="button"
+                onClick={() => scrollTo(i)}
+                aria-label={`Select image ${i + 1}`}
+                aria-current={active}
+                className={`relative aspect-square cursor-pointer overflow-hidden rounded-lg transition ${active ? "ring-primary ring-2" : "hover:opacity-75"}`}
+              >
+                <Image
+                  src={img.thumb}
+                  alt=""
+                  fill
+                  className={`object-cover ${active ? "opacity-50" : ""}`}
+                  sizes="6rem"
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
-import type {Metadata} from "next";
-import {Geist, Geist_Mono} from "next/font/google";
+import type { Metadata } from "next";
+import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,7 +24,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}>
-      <body className="min-h-full flex flex-col max-w-7xl mx-auto px-6 bg-amber-200">{children}</body>
+      <body className="mx-auto flex min-h-full max-w-7xl flex-col bg-amber-200 px-6">
+        {children}
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,12 +1,16 @@
 import { Header } from "./components/Header";
 import { ProductGallery } from "./components/ProductGallery";
+import { ProductInfo } from "./components/ProductInfo";
 
 export default function Home() {
   return (
     <div className="flex flex-1 flex-col">
       <Header />
       <main className="mx-auto w-full max-w-6xl px-0 py-0 md:px-6 md:py-16 lg:px-10 lg:py-20">
-        <ProductGallery />
+        <div className="flex flex-col gap-0 lg:flex-row lg:items-center lg:gap-20">
+          <ProductGallery />
+          <ProductInfo />
+        </div>
       </main>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,13 @@
-import {Header} from "./components/Header";
+import { Header } from "./components/Header";
+import { ProductGallery } from "./components/ProductGallery";
 
 export default function Home() {
   return (
-    <div className="">
+    <div className="flex flex-1 flex-col">
       <Header />
+      <main className="mx-auto w-full max-w-6xl px-0 py-0 md:px-6 md:py-16 lg:px-10 lg:py-20">
+        <ProductGallery />
+      </main>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "ecommerce-product-page-main",
             "version": "0.1.0",
             "dependencies": {
+                "embla-carousel-react": "^8.6.0",
                 "next": "16.2.4",
                 "react": "19.2.4",
                 "react-dom": "19.2.4"
@@ -2844,6 +2845,34 @@
             "integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/embla-carousel": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+            "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+            "license": "MIT"
+        },
+        "node_modules/embla-carousel-react": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+            "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+            "license": "MIT",
+            "dependencies": {
+                "embla-carousel": "8.6.0",
+                "embla-carousel-reactive-utils": "8.6.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+            }
+        },
+        "node_modules/embla-carousel-reactive-utils": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+            "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+            "license": "MIT",
+            "peerDependencies": {
+                "embla-carousel": "8.6.0"
+            }
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "format:check": "prettier --check ."
     },
     "dependencies": {
+        "embla-carousel-react": "^8.6.0",
         "next": "16.2.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary

  상품 상세 페이지 본문을 구현했습니다. 왼쪽은 EmblaCarousel 기반 이미지 갤러리, 데스크톱(md+)에선 메인 이미지 클릭 시 라이트박스로 확대 뷰가 열립니다. 오른쪽 상품 정보 섹션은
  **UI** 만들고 수량·장바구니 연결은 이후 단계에서 진행합니다.

  ## Changes

  ### ⓐ ProductGallery (`app/components/ProductGallery.tsx`)
  - `embla-carousel-react` 도입, `useEmblaCarousel({ loop: true })`로 메인 이미지 캐러셀
  - `emblaApi.on("select")` 이벤트로 `selectedIndex` 동기화
  - **반응형**
    - 모바일(<768): `edge-to-edge` 이미지 + 좌우 원형 prev/next 버튼 오버레이, 썸네일 숨김
    - md+: `rounded-xl` 이미지 + 썸네일 4개 그리드, prev/next 오버레이 숨김
  - 썸네일 선택 상태: `ring-2 ring-primary` + 이미지 `opacity-50`
  - 메인 이미지 클릭 시 `window.matchMedia("(min-width: 768px)")`로 데스크톱 판별 후 라이트박스 open

  ### ⓑ ProductLightbox (`app/components/ProductLightbox.tsx`)
  - **md+ 전용** (`hidden md:flex` + 부모에서도 미렌더 이중 방어)
  - 자체 Embla 인스턴스 (`startIndex: initialIndex`)
  - 열릴 때마다 `scrollTo(initialIndex, true)`로 현재 메인 이미지와 동기화
  - 닫기: X 버튼 / 백드롭 클릭 / ESC (`useEscapeKey` 재사용)
  - body 스크롤 잠금 (`document.body.style.overflow`)
  - inline SVG로 닫기 X 구현 → `group-hover:fill-primary`로 호버 색 변경
  - 갤러리와 양방향 동기화: 라이트박스 내 이미지 전환 시 `onIndexChange` 콜백으로 상위 Embla도 이동 → 닫았을 때 마지막 본 이미지 유지
  - `role="dialog"`, `aria-modal`, `aria-label` 접근성 속성

  ### ⓒ ProductInfo (`app/components/ProductInfo.tsx`)
  - **서버 컴포넌트**로 정적 렌더, 상태/이벤트 없음
  - 렌더 항목: company, name, description, price, 할인 뱃지(`bg-foreground text-white`), originalPrice
  - 수량 선택기 / Add to cart 버튼은 **틀만** — 핸들러 없음
  - 반응형
    - 모바일: 가격·뱃지와 원가가 `justify-between`으로 한 줄에 배치, 수량·버튼 세로 스택
    - lg+: 가격·원가 세로 스택, 수량·버튼 가로 배치 (수량 `w-40` 고정, Add to cart `flex-1`)
  - Add to cart 카트 아이콘은 `[filter:brightness(0)]`로 검정 변환